### PR TITLE
Master fix jerrycanrefuel (#686)

### DIFF
--- a/Altis_Life.Altis/core/items/fn_jerryCanRefuel.sqf
+++ b/Altis_Life.Altis/core/items/fn_jerryCanRefuel.sqf
@@ -56,8 +56,8 @@ if (_action) then {
         _progress progressSetPosition _cP;
         _pgText ctrlSetText format ["%3 (%1%2)...",round(_cP * 100),"%",_title];
         if (_cP >= 1) exitWith {};
-        if (!alive player) exitWith {life_action_inUse = false;};
-        if (life_interrupted) exitWith {life_interrupted = false; life_action_inUse = false;};
+        if (!alive player) exitWith {};
+        if (life_interrupted) exitWith {};
     };
 
     //Kill the UI display and check for various states


### PR DESCRIPTION
* fix fn_jerrycanrefuel

removed/commented out setting life_action_isUse and life_interruped to false directly within exitWith to trigger if() after the loop to return from it before the full jerrycan is given to inventory

* Update fn_jerryCanRefuel.sqf

removed commented out stuff as requested

<!-- Please review the guidelines for contributing to this repository. The link is to the right under 'helpful resources'. -->

<!-- It is recommended that changes are committed to a new branch on your fork. Avoid directly editing the `master` branch. -->

Resolves #<!-- issue ID here -->. <!-- If applicable. -->

#### Changes proposed in this pull request: 
- <!-- Describe the changes that your pull request makes. -->

- [ ] I have tested my changes and corrected any errors found
